### PR TITLE
correctly parse metadata/record files, with respect to unicode characters

### DIFF
--- a/rewheel/__init__.py
+++ b/rewheel/__init__.py
@@ -1,4 +1,5 @@
 import argparse
+import codecs
 import csv
 import email.parser
 import os
@@ -86,11 +87,11 @@ def get_wheel_name(record_path):
     """Return proper name of the wheel, without .whl."""
 
     wheel_info_path = os.path.join(os.path.dirname(record_path), 'WHEEL')
-    with open(wheel_info_path) as wheel_info_file:
+    with codecs.open(wheel_info_path, encoding='utf-8') as wheel_info_file:
         wheel_info = email.parser.Parser().parsestr(wheel_info_file.read())
 
     metadata_path = os.path.join(os.path.dirname(record_path), 'METADATA')
-    with open(metadata_path) as metadata_file:
+    with codecs.open(metadata_path, encoding='utf-8') as metadata_file:
         metadata = email.parser.Parser().parsestr(metadata_file.read())
 
     # construct name parts according to wheel spec
@@ -113,7 +114,8 @@ def get_records_to_pack(site_dir, record_relpath):
     - list of files that shouldn't be written or need some processing
       (pyc and pyo files, scripts)
     """
-    with open(os.path.join(site_dir, record_relpath)) as record_file:
+    record_file_path = os.path.join(site_dir, record_relpath)
+    with codecs.open(record_file_path, encoding='utf-8') as record_file:
         record_contents = record_file.read()
     # temporary fix for https://github.com/pypa/pip/issues/1376
     # we need to ignore files under ".data" directory


### PR DESCRIPTION
I'm working on building python 3.4.1 and setuptools 5.5.1 for EL6, using the Fedora RPMs as a guide.  I get multiple failures during the test suite, all similar to below.

```
======================================================================
ERROR: test_basic_bootstrapping (test.test_ensurepip.TestBootstrap)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/Python-3.4.1/Lib/test/test_ensurepip.py", line 52, in test_basic_bootstrapping
    ensurepip.bootstrap()
  File "/builddir/build/BUILD/Python-3.4.1/Lib/ensurepip/__init__.py", line 105, in bootstrap
    new_whl = rewheel.rewheel_from_record(dr, rewheel_dir.name)
  File "/builddir/build/BUILD/Python-3.4.1/Lib/ensurepip/rewheel/__init__.py", line 63, in rewheel_from_record
    new_wheel_name = get_wheel_name(record_path)
  File "/builddir/build/BUILD/Python-3.4.1/Lib/ensurepip/rewheel/__init__.py", line 90, in get_wheel_name
    metadata = email.parser.Parser().parsestr(open(metadata_path).read())
  File "/builddir/build/BUILD/Python-3.4.1/Lib/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 9749: ordinal not in range(128)
```

In setuptools 5.5.1, there is an **é** character on line 234 of the METADATA file.  Fedora rawhide has setuptools 2.0, which does not have this character.  I could be interpreting this wrong, but I believe that the failures I am seeing are due to the fact that rewheel is opening these files with a simple open(), instead of the recommended codecs.open(), which can be made unicode-safe.

http://stackoverflow.com/questions/147741/character-reading-from-file-in-python

Feel free to tell me I'm totally off-base on this one, but this patch should fix it.
